### PR TITLE
feat(dicom): add DICOM tags to Item metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,58 @@ io:
   segmentGroupSaveFormat: "nrrd"
 ```
 
+## Grider Plugin Configuration File
+
+To show DICOM tags in a table view, add a `.large_image_config.yaml` file higher in the Girder folder hierarchy. When a DICOM file is imported/uploaded, its DICOM tags are saved on the Item metadata under the top level `dicom` key.
+
+More information on `.large_image_config.yaml` here:
+https://girder.github.io/large_image/girder_config_options.html#large-image-config-yaml
+
+Example `.large_image_config.yaml` file:
+
+```yml
+# If present, show a table with column headers in item lists
+itemList:
+  # Show these columns in order from left to right.  Each column has a
+  # "type" and "value".  It optionally has a "title" used for the column
+  # header, and a "format" used for searching and filtering.  The "label",
+  # if any, is displayed to the left of the column value.  This is more
+  # useful in an grid view than in a column view.
+  columns:
+    - # The "record" type is from the default item record.  The value is
+      # one of "name", "size", or "controls".
+      type: record
+      value: name
+    - type: record
+      value: size
+    - # The "metadata" type is taken from the item's "meta" contents.  It
+      # can be a nested key by using dots in its name.
+      type: metadata
+      value: dicom.Modality
+      title: Modality
+    - type: metadata
+      value: dicom.BodyPartExamined
+      title: Body Part Examined
+    - type: metadata
+      value: dicom.StudyDate
+      title: Study Date
+    - type: metadata
+      value: dicom.StudyDescription
+      title: Study Description
+    - type: metadata
+      value: dicom.SeriesDescription
+      title: Series Description
+    - type: metadata
+      value: dicom.ManufacturerModelName
+      title: Manufacturer Model Name
+    - type: metadata
+      value: dicom.StudyInstanceUID
+      title: Study Instance UID
+    - type: metadata
+      value: dicom.SeriesInstanceUID
+      title: Series Instance UID
+```
+
 ## CORS Error Workaround by Proxying Assetstores
 
 VolView will error if it loads a file from a S3 bucket asset store without some

--- a/girder_volview/__init__.py
+++ b/girder_volview/__init__.py
@@ -29,7 +29,7 @@ from girder.models.group import Group
 # server settings (from girder.cfg file probably) for proxiable endpoint below
 from girder.utility import config
 
-from .dicom import addDicomTagsToItem
+from .dicom import setupEventHandlers
 from .utils import (
     isSessionItem,
     isLoadableImage,
@@ -425,7 +425,7 @@ class GirderPlugin(plugin.GirderPlugin):
     CLIENT_SOURCE_PATH = "web_client"
 
     def load(self, info):
-        events.bind("data.process", "girder_volview", addDicomTagsToItem)
+        setupEventHandlers()
 
         info["apiRoot"].item.route("GET", (":itemId", "volview"), downloadManifest)
         info["apiRoot"].folder.route(

--- a/girder_volview/__init__.py
+++ b/girder_volview/__init__.py
@@ -168,7 +168,7 @@ def downloadDatasets(self, item):
         sansSessions = [
             fileEntry
             for fileEntry in Item().fileList(item, subpath=False)
-            if isLoadableImage(fileEntry[0])
+            if isLoadableImage(fileEntry[1])
         ]
         for path, file in sansSessions:
             for data in zip.addFile(file, path):
@@ -268,7 +268,7 @@ def downloadResourceManifest(self, folder, folders, items):
         else:
             # Load selected folders and items excluding child session.volview.zip and .volview_config.yaml
             files = getFiles(Folder, selectedFolders) + getFiles(Item, selectedItems)
-            files = [file for file in files if isLoadableImage(file[0])]
+            files = [file for file in files if isLoadableImage(file[1])]
     return filesToManifest(files, folder["_id"])
 
 

--- a/girder_volview/dicom.py
+++ b/girder_volview/dicom.py
@@ -22,6 +22,14 @@ def handleFileSave(event):
     return addDicomTagsToItemMetadata(event.info)
 
 
+def maybeUpgradeMimeType(file):
+    mimeType = file.get("mimeType")
+    # asset store import can set mimeType to None.  Manual upload sets mimeType to "application/octet-stream"
+    if mimeType is None or mimeType == "application/octet-stream":
+        file["mimeType"] = "application/dicom"
+        File().save(file)
+
+
 # Code modified from https://github.com/girder/girder/blob/master/plugins/dicom_viewer/girder_dicom_viewer/__init__.py
 def addDicomTagsToItemMetadata(file):
     itemId = file.get("itemId")
@@ -31,6 +39,7 @@ def addDicomTagsToItemMetadata(file):
     dicomMetadata = _parseFile(file)
     if dicomMetadata is None:
         return  # not a dicom file
+    maybeUpgradeMimeType(file)
     itemMeta = {"dicom": dicomMetadata}
     item = Item().load(itemId, force=True)
     Item().setMetadata(item, itemMeta)

--- a/girder_volview/dicom.py
+++ b/girder_volview/dicom.py
@@ -19,17 +19,15 @@ def setupEventHandlers():
 
 
 def handleFileSave(event):
-    return addDicomTagsToItem(event.info)
+    return addDicomTagsToItemMetadata(event.info)
 
 
 # Code modified from https://github.com/girder/girder/blob/master/plugins/dicom_viewer/girder_dicom_viewer/__init__.py
-def addDicomTagsToItem(file):
-    """
-    Add DICOM tags to Item metadata.
-    """
-    itemId = file["itemId"]
-    if not itemId:
+def addDicomTagsToItemMetadata(file):
+    itemId = file.get("itemId")
+    if itemId is None:
         return
+
     dicomMetadata = _parseFile(file)
     if dicomMetadata is None:
         return  # not a dicom file
@@ -124,6 +122,9 @@ def _coerceMetadata(dataset):
 
 
 def _parseFile(f):
+    if "linkUrl" in f:
+        # link file, File().open() will error
+        return None
     try:
         # download file and try to parse dicom
         with File().open(f) as fp:

--- a/girder_volview/dicom.py
+++ b/girder_volview/dicom.py
@@ -1,0 +1,120 @@
+import datetime
+
+import pydicom
+import pydicom.valuerep
+import pydicom.multival
+import pydicom.sequence
+
+from girder.models.item import Item
+from girder.models.file import File
+
+
+# Code modified from https://github.com/girder/girder/blob/master/plugins/dicom_viewer/girder_dicom_viewer/__init__.py
+def addDicomTagsToItem(event):
+    """
+    Add DICOM tags to Item metadata.
+    """
+    file = event.info["file"]
+    dicomMetadata = _parseFile(file)
+    if dicomMetadata is None:
+        return
+
+    itemMeta = {"dicom": dicomMetadata}
+    item = Item().load(file["itemId"], force=True)
+    Item().setMetadata(item, itemMeta)
+
+
+def _coerceValue(value):
+    # For binary data, see if it can be coerced further into utf8 data.  If
+    # not, mongo won't store it, so don't accept it here.
+    if isinstance(value, bytes):
+        if b"\x00" in value:
+            raise ValueError("Binary data with null")
+        try:
+            value.decode("utf-8")
+        except UnicodeDecodeError:
+            raise ValueError("Binary data that cannot be stored as utf-8")
+    # Many pydicom value types are subclasses of base types; to ensure the value can be serialized
+    # to MongoDB, cast the value back to its base type
+    for knownBaseType in {
+        int,
+        float,
+        bytes,
+        str,
+        datetime.datetime,
+        datetime.date,
+        datetime.time,
+    }:
+        if isinstance(value, knownBaseType):
+            return knownBaseType(value)
+
+    # pydicom does not treat the PersonName type as a subclass of a text type
+    if isinstance(value, pydicom.valuerep.PersonName):
+        return value.encode("utf-8")
+
+    # Handle lists (MultiValue) recursively
+    if isinstance(value, pydicom.multival.MultiValue):
+        if isinstance(value, pydicom.sequence.Sequence):
+            # A pydicom Sequence is a nested list of Datasets, which is too complicated to flatten
+            # now
+            raise ValueError("Cannot coerce a Sequence")
+        return list(map(_coerceValue, value))
+
+    raise ValueError("Unknown type", type(value))
+
+
+def _coerceMetadata(dataset):
+    metadata = {}
+
+    # Use simple iteration instead of "dataset.iterall", to prevent recursing into Sequences, which
+    # are too complicated to flatten now
+    # The dataset iterator is
+    #   for tag in sorted(dataset.keys()):
+    #       yield dataset[tag]
+    # but we want to ignore certain exceptions of delayed data loading, so
+    # we iterate through the dataset ourselves.
+    for tag in dataset.keys():
+        try:
+            dataElement = dataset[tag]
+        except OSError:
+            continue
+        if dataElement.tag.element == 0:
+            # Skip Group Length tags, which are always element 0x0000
+            continue
+
+        # Use "keyword" instead of "name", as the keyword is a simpler and more uniform string
+        # See: http://dicom.nema.org/medical/dicom/current/output/html/part06.html#table_6-1
+        # For unknown / private tags, allow pydicom to create a string representation like
+        # "(0013, 1010)"
+        tagKey = (
+            dataElement.keyword
+            if dataElement.keyword and not dataElement.tag.is_private
+            else str(dataElement.tag)
+        )
+
+        try:
+            tagValue = _coerceValue(dataElement.value)
+        except ValueError:
+            # Omit tags where the value cannot be coerced to JSON-encodable types
+            continue
+
+        metadata[tagKey] = tagValue
+
+    return metadata
+
+
+def _parseFile(f):
+    try:
+        # download file and try to parse dicom
+        with File().open(f) as fp:
+            dataset = pydicom.dcmread(
+                fp,
+                # don't read huge fields, esp. if this isn't even really dicom
+                defer_size=1024,
+                # don't read image data, just metadata
+                stop_before_pixels=True,
+            )
+            return _coerceMetadata(dataset)
+    except pydicom.errors.InvalidDicomError:
+        # if this error occurs, probably not a dicom file
+        return None

--- a/girder_volview/dicom.py
+++ b/girder_volview/dicom.py
@@ -9,6 +9,7 @@ import pydicom.sequence
 from girder import events
 from girder.models.item import Item
 from girder.models.file import File
+from girder.exceptions import GirderException
 
 MAX_TAG_SIZE = 1024 * 128  # bytes
 
@@ -134,6 +135,7 @@ def _parseFile(f):
                 stop_before_pixels=True,
             )
             return _coerceMetadata(dataset)
-    except pydicom.errors.InvalidDicomError:
-        # if this error occurs, probably not a dicom file
+    except (pydicom.errors.InvalidDicomError, GirderException):
+        # If pydicom.errors.InvalidDicomError occurs, probably not a dicom file.
+        # If GirderException, the file may have been deleted between scanning for import and handling the event
         return None

--- a/girder_volview/utils.py
+++ b/girder_volview/utils.py
@@ -4,7 +4,50 @@ from girder.constants import AccessType
 
 SESSION_ZIP_EXTENSION = ".volview.zip"
 
-IGNORE_EXTENSIONS = [".yaml", ".svs"]
+# https://github.com/Kitware/VolView/blob/main/src/io/mimeTypes.ts
+LOADABLE_EXTENSIONS = [
+    # VolView app
+    ".json",
+    ".zip",
+    ".vti",
+    ".vtp",
+    ".stl",
+    # @itk-wasm/image-io
+    ".bmp",
+    ".dcm",
+    ".gipl",
+    ".gipl.gz",
+    ".hdf5",
+    ".jpg",
+    ".jpeg",
+    ".iwi",
+    ".iwi.cbor",
+    ".iwi.cbor.zst",
+    ".lsm",
+    ".mnc",
+    ".mnc.gz",
+    ".mnc2",
+    ".mgh",
+    ".mgz",
+    ".mgh.gz",
+    ".mha",
+    ".mhd",
+    ".mrc",
+    ".nia",
+    ".nii",
+    ".nii.gz",
+    ".hdr",
+    ".nrrd",
+    ".nhdr",
+    ".png",
+    ".pic",
+    ".tif",
+    ".tiff",
+    ".vtk",
+    ".isq",
+    ".aim",
+    ".fdf",
+]
 
 
 def isSessionItem(item):
@@ -22,9 +65,9 @@ def isSessionFile(path):
 def isLoadableImage(path):
     if isSessionFile(path):
         return False
-    if any(path.endswith(extension) for extension in IGNORE_EXTENSIONS):
-        return False
-    return True
+    if any(path.endswith(extension) for extension in LOADABLE_EXTENSIONS):
+        return True
+    return False
 
 
 def makeFileDownloadUrl(fileModel):

--- a/girder_volview/utils.py
+++ b/girder_volview/utils.py
@@ -4,6 +4,8 @@ from girder.constants import AccessType
 
 SESSION_ZIP_EXTENSION = ".volview.zip"
 
+IGNORE_EXTENSIONS = [".yaml", ".svs"]
+
 
 def isSessionItem(item):
     if item and SESSION_ZIP_EXTENSION in item["name"]:
@@ -20,7 +22,7 @@ def isSessionFile(path):
 def isLoadableImage(path):
     if isSessionFile(path):
         return False
-    if path.endswith("volview_config.yaml"):
+    if any(path.endswith(extension) for extension in IGNORE_EXTENSIONS):
         return False
     return True
 

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ with open("README.md") as readme_file:
 requirements = [
     "girder>=3.0.0a1",
     "pyyaml",
+    "pydicom>=2",
 ]
 
 setup(


### PR DESCRIPTION
Add .large_image_config.yaml example to README showing how to setup the columns for DICOM tag metadata.

![image](https://github.com/DigitalSlideArchive/girder_volview/assets/16823231/eb334278-8b57-4c94-8dc9-954463992052)

Only load greenlisted file extension in VolView. 

closes #32