### PR TITLE
When checking if a file is a volview file, use the current user.

### DIFF
--- a/girder_volview/utils.py
+++ b/girder_volview/utils.py
@@ -97,9 +97,9 @@ def isDicomFile(file):
     )
 
 
-def isLoadableFile(file):
+def isLoadableFile(file, user=None):
     if isTiffFile(file) or isDicomFile(file):
-        item = Item().load(file.get("itemId"), level=AccessType.READ)
+        item = Item().load(file.get("itemId"), user=user, level=AccessType.READ)
         if isTiffFile(file):
             return not item.get("largeImage")
         if item.get("meta", {}).get("dicom", {}).get("Modality", "") == "SM":
@@ -111,10 +111,10 @@ def isLoadableFile(file):
     return file.get("mimeType") in LOADABLE_MIMES
 
 
-def isLoadableImage(file):
+def isLoadableImage(file, user=None):
     if isSessionFile(file):
         return False
-    return isLoadableFile(file)
+    return isLoadableFile(file, user)
 
 
 def makeFileDownloadUrl(fileModel):
@@ -169,7 +169,7 @@ def sameLevelSessionFile(fileEntry):
     return directChildSessionZip and isSessionFile(fileEntry[1])
 
 
-def singleVolViewZipOrImageFiles(fileEntries):
+def singleVolViewZipOrImageFiles(fileEntries, user=None):
     sessions = [
         fileEntry for fileEntry in fileEntries if sameLevelSessionFile(fileEntry)
     ]
@@ -178,7 +178,7 @@ def singleVolViewZipOrImageFiles(fileEntries):
         newestSession = max(sessions, key=lambda file: file[1].get("created"))
         return [newestSession]
     else:
-        return [fileEntry for fileEntry in fileEntries if isLoadableImage(fileEntry[1])]
+        return [fileEntry for fileEntry in fileEntries if isLoadableImage(fileEntry[1], user)]
 
 
 def idStringToIdList(idString):

--- a/girder_volview/web_client/views/itemPage.js
+++ b/girder_volview/web_client/views/itemPage.js
@@ -18,6 +18,7 @@ wrap(ItemView, "render", function (render) {
         restRequest({
             url: `item/${id}/volview_loadable`,
             method: "GET",
+            error: null,
         }).done((loadableJSON) => {
             if (loadableJSON.loadable) {
                 setupButton(this.$el, this.model);


### PR DESCRIPTION
Otherwise, for instance, an item in a private folder returns a 403 even if the user has permission for the folder.