### PR TITLE
Better open volview from item lists

### DIFF
--- a/girder_volview/web_client/package.json
+++ b/girder_volview/web_client/package.json
@@ -15,6 +15,9 @@
     "girderPlugin": {
         "name": "volview",
         "main": "./main.js",
+        "dependencies": [
+            "large_image"
+        ],
         "webpack": "webpack.helper"
     },
     "scripts": {

--- a/girder_volview/web_client/views/HierarchyWidget.js
+++ b/girder_volview/web_client/views/HierarchyWidget.js
@@ -1,9 +1,9 @@
 import HierarchyWidget from "@girder/core/views/widgets/HierarchyWidget";
-import ItemListWidget from "@girder/core/views/widgets/ItemListWidget";
+import ItemListWidget from "@girder/large_image/views/itemList";
 import { restRequest } from "@girder/core/rest";
 import { confirm } from "@girder/core/dialog";
 import { wrap } from "@girder/core/utilities/PluginUtils";
-import { addButton, openResources } from "./open";
+import { addButton, openResources, openGroupedItemURL, openItemURL, openResourcesURL } from "./open";
 
 const openFolder = '<i class="icon-link-ext"></i>Open Folder in VolView</a>';
 const openChecked = '<i class="icon-link-ext"></i>Open Checked in VolView</a>';
@@ -143,3 +143,31 @@ wrap(ItemListWidget, "render", function (render) {
         .find(".open-in-volview");
     updateButtonVisibility(button, id);
 });
+
+ItemListWidget.registeredApplications['volview'] = {
+    name: 'VolView',
+    // icon:
+    check: (modelType, model, folder) => {
+        if (modelType === 'item') {
+            if (model.get('name').endsWith('volview.zip')) {
+                // use this
+            } else {
+                try {
+                    if (!model.get('meta') || !model.get('meta').dicom || model.get('meta').dicom.Modality === 'SM') {
+                        return false;
+                    }
+                } catch (e) {
+                    return false;
+                }
+            }
+            if (model.get('meta')._grouping) {
+                return {url: openGroupedItemURL(model, folder)};
+            }
+            return {url: openItemURL(model)};
+        }
+        if (modelType === 'folder') {
+            // TODO: this needs to mimic what is done in python
+            return {url: openResourcesURL(model, {})};
+        }
+    }
+};

--- a/girder_volview/web_client/views/open.js
+++ b/girder_volview/web_client/views/open.js
@@ -16,16 +16,19 @@ export function addButton($el, siblingSelector) {
     return button;
 }
 
-const origin = globalThis.location.origin;
-const volViewPath = `${origin}/static/built/plugins/volview/index.html`;
+const volViewPath = `static/built/plugins/volview/index.html`;
 
-export function openItem(item) {
+export function openItemURL(item) {
     const itemRoute = `/${getApiRoot()}/item/${item.id}`;
     const saveParam = `&save=${itemRoute}/volview`;
     const manifestUrl = `${itemRoute}/volview`;
     const downloadParams = `&names=[manifest.json]&urls=${manifestUrl}`;
     const newTabUrl = `${volViewPath}?${saveParam}${downloadParams}`;
-    window.open(newTabUrl, "_blank").focus();
+    return newTabUrl;
+}
+
+export function openItem(item) {
+    window.open(openItemURL(item), "_blank").focus();
 }
 
 function resourcesToDownloadParams(folderId, resources) {
@@ -35,7 +38,7 @@ function resourcesToDownloadParams(folderId, resources) {
     return `&names=[manifest.json]&urls=${encodeURIComponent(manifestUrl)}`;
 }
 
-export function openResources(folder, resources) {
+export function openResourcesURL(folder, resources) {
     const folderRoute = `/${getApiRoot()}/folder/${folder.id}`;
     const metaData = {
         linkedResources: {
@@ -48,5 +51,29 @@ export function openResources(folder, resources) {
     )}`;
     const downloadParams = resourcesToDownloadParams(folder.id, resources);
     const newTabUrl = `${volViewPath}?${saveParam}${downloadParams}`;
-    window.open(newTabUrl, "_blank").focus();
+    return newTabUrl;
+}
+
+export function openResources(folder, resources) {
+    window.open(openResourcesURL(folder, resources), "_blank").focus();
+}
+
+export function openGroupedItemURL(item, folder) {
+    const folderId = folder ? folder.id : item.get('folderId');
+    const folderRoute = `/${getApiRoot()}/folder/${folderId}`;
+    const groups = item.get('meta')._grouping || {};
+    const filter = {};
+    (groups.keys || []).forEach((key, idx) => {
+        if ((groups.values || [])[idx] !== undefined) {
+            filter[key] = groups.values[idx];
+        }
+    });
+    const metaData = {linkedResources: {filter: filter}};
+    const saveParam = `&save=${folderRoute}/volview?metadata=${encodeURIComponent(
+        JSON.stringify(metaData)
+    )}`;
+    const manifestUrl = `/${getApiRoot()}/folder/${folderId}/volview?filters=${JSON.stringify(filter)}`;
+    const downloadParams = `&names=[manifest.json]&urls=${encodeURIComponent(manifestUrl)}`;
+    const newTabUrl = `${volViewPath}?${saveParam}${downloadParams}`;
+    return newTabUrl;
 }

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,8 @@ with open("README.md") as readme_file:
     readme = readme_file.read()
 
 requirements = [
-    "girder>=3.0.0a1",
+    "girder>=3",
+    "girder-large-image>=1.30.1",
     "pyyaml",
     "pydicom>=2",
 ]


### PR DESCRIPTION
This requires a new enough version of large_image to be useful.

Specifically, this exposes open buttons on items in item lists.  If the item lists are grouped and filtered, this will open the filter set and have appropriately named session files.  Filters have a pipeline that given a parent folder find all the items that match a filter in any recursion level and then add the files of those items to the open set. This is passed compactly, so any number of files can be opened with short paths.

Note that this does nothing to change the existing checked item and folder behavior.  A future work would be to generalize folder-level "app" open behavior.  This will require determining whether a list of folders can each be opened, which is currently an expensive call.

Although there is a tox lint environment, it doesn't seem to be enforced in any manner.  I'd recommend adding an autoformater (either autopep8 or black, etc.) for both python and javascript.