### PR TITLE
add toolbar button relative to parent instead of sibling

### DIFF
--- a/girder_volview/web_client/views/HierarchyWidget.js
+++ b/girder_volview/web_client/views/HierarchyWidget.js
@@ -65,7 +65,7 @@ wrap(HierarchyWidget, "render", function (render) {
     ) {
         return;
     }
-    const button = addButton(this.$el, ".g-folder-header-buttons .btn-info");
+    const button = addButton(this.$el, ".g-folder-header-buttons");
     if (!button) {
         return;
     }

--- a/girder_volview/web_client/views/open.js
+++ b/girder_volview/web_client/views/open.js
@@ -3,15 +3,15 @@ import { getApiRoot } from "@girder/core/rest";
 const openButton = `<a class="btn btn-sm btn-primary open-in-volview hidden" style="margin-left: 10px" role="button">
                                 <i class="icon-link-ext"></i>Open in VolView</a>`;
 
-export function addButton($el, siblingSelector) {
-    const sibling = $el.find(siblingSelector);
-    if (!sibling.length) {
+export function addButton($el, parentSelector) {
+    const parent = $el.find(parentSelector);
+    if (!parent.length) {
         console.warn(
-            `Tried to add VolView button, but sibling element not found with selector: ${siblingSelector}`
+            `Tried to add VolView button, but parent element not found with selector: ${parentSelector}`
         );
         return;
     }
-    sibling.before(openButton);
+    parent.prepend(openButton);
     const button = $el.find(".open-in-volview")[0];
     return button;
 }


### PR DESCRIPTION
The sibling buttons like the info button may get moved around, as is being done in some experimental UX changes. This changes the selector to the parent to be more resilient.