### PR TITLE
fix: Handle OSError when trying to read dicom files

### DIFF
--- a/girder_volview/dicom.py
+++ b/girder_volview/dicom.py
@@ -145,7 +145,8 @@ def _parseFile(f):
                 stop_before_pixels=True,
             )
             return _coerceMetadata(dataset)
-    except (pydicom.errors.InvalidDicomError, GirderException):
+    except (pydicom.errors.InvalidDicomError, GirderException, OSError):
         # If pydicom.errors.InvalidDicomError occurs, probably not a dicom file.
         # If GirderException, the file may have been deleted between scanning for import and handling the event
+        # OSError can occur on files that are partly written and unclosed
         return None


### PR DESCRIPTION
I had a bad file (not a dicom) on my file system that threw an OSError.  This guards against that.