### PR TITLE
Don't throw an error when a button doesn't exist

### DIFF
--- a/girder_volview/web_client/views/HierarchyWidget.js
+++ b/girder_volview/web_client/views/HierarchyWidget.js
@@ -9,7 +9,9 @@ const openFolder = '<i class="icon-link-ext"></i>Open Folder in VolView</a>';
 const openChecked = '<i class="icon-link-ext"></i>Open Checked in VolView</a>';
 
 function setButtonVisibility(button, visible = true) {
-    if (button.length === 0) throw new Error("Button not found");
+    if (button.length === 0) {
+        return;
+    }
     if (visible) {
         button.removeClass("hidden");
     } else {


### PR DESCRIPTION
We are throwing in a file selection dialog where this button can't exist.  Just return quietly.

This happens, for instance, when I select a file in an item task.