### PR TITLE
fix(utils): handle None item in isLoadableFile

### DIFF
--- a/girder_volview/utils.py
+++ b/girder_volview/utils.py
@@ -102,6 +102,8 @@ def isDicomFile(file):
 def isLoadableFile(file, user=None):
     if isTiffFile(file) or isDicomFile(file):
         item = Item().load(file.get("itemId"), user=user, level=AccessType.READ)
+        if item is None:
+            return False
         if isTiffFile(file):
             return not item.get("largeImage")
         if item.get("meta", {}).get("dicom", {}).get("Modality", "") == "SM":


### PR DESCRIPTION
  Prevent AttributeError when Item().load() returns None for files
  with missing or inaccessible items. Return False for such files
  instead of traceback error on item.get("largeImage").