### PR TITLE
Ensure plugin load order

### DIFF
--- a/girder_volview/__init__.py
+++ b/girder_volview/__init__.py
@@ -582,6 +582,7 @@ class GirderPlugin(plugin.GirderPlugin):
     CLIENT_SOURCE_PATH = "web_client"
 
     def load(self, info):
+        plugin.getPlugin('large_image').load(info)
         setupEventHandlers()
 
         info["apiRoot"].item.route(


### PR DESCRIPTION
The client requires large_image.  It seems like it _should_ be sufficient to say this in the package.json, but the order the javascript is loaded is dictated by the python order.  Without asking to load large_image, it is possible the girder volview plugin will be loaded first and fail.