### PR TITLE
fix(dicom): ignore deferred read tag error

### DIFF
--- a/girder_volview/dicom.py
+++ b/girder_volview/dicom.py
@@ -145,8 +145,9 @@ def _parseFile(f):
                 stop_before_pixels=True,
             )
             return _coerceMetadata(dataset)
-    except (pydicom.errors.InvalidDicomError, GirderException, OSError):
+    except (pydicom.errors.InvalidDicomError, GirderException, OSError, ValueError):
         # If pydicom.errors.InvalidDicomError occurs, probably not a dicom file.
         # If GirderException, the file may have been deleted between scanning for import and handling the event
         # OSError can occur on files that are partly written and unclosed
+        # ValueError can occur with corrupted DICOM tags or deferred read issues
         return None


### PR DESCRIPTION
Avoid errors like these stoping asset store import
```
Failed with Deferred read tag (0000,0000) does not match original (0004,00A6)
```
If a DICOM file hits that, the file will not have DICOM tags in its Grider metadata.