### PR TITLE
fix(dicom): optimize DICOM import performance for S3 asset stores

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ new CopyWebpackPlugin([
 ```
 
 Then build VolView with the right flags:
-https://github.com/PaulHax/girder_volview/blob/main/volview-girder-client/buildvolview.sh#L14C2-L14C108
+https://github.com/DigitalSlideArchive/girder_volview/blob/main/volview-girder-client/buildvolview.sh#L14C2-L14C108
 
 ```
 VITE_REMOTE_SERVER_URL= VITE_ENABLE_REMOTE_SAVE=true npm run build

--- a/girder_volview/web_client/package.json
+++ b/girder_volview/web_client/package.json
@@ -7,7 +7,7 @@
     "license": "Apache-2.0",
     "dependencies": {
         "copy-webpack-plugin": "^4.5.2",
-        "volview-girder-client": "1.20.0"
+        "volview-girder-client": "1.21.0"
     },
     "peerDependencies": {
         "@girder/core": "*"

--- a/volview-girder-client/buildvolview.sh
+++ b/volview-girder-client/buildvolview.sh
@@ -6,7 +6,7 @@ cd VolView
 # fetch just one commit
 git init
 git remote add origin https://github.com/Kitware/VolView.git
-git fetch origin 6c1f808b5d50c0ce3fce5b87f1052399efd162ad --depth 1
+git fetch origin 83564b8104d425094cbf233fe3cd5a66818e72ef --depth 1
 git reset --hard FETCH_HEAD
 
 npm install

--- a/volview-girder-client/package.json
+++ b/volview-girder-client/package.json
@@ -1,6 +1,6 @@
 {
     "name": "volview-girder-client",
-    "version": "1.20.0",
+    "version": "1.21.0",
     "description": "Built VolView with public path for DSA",
     "main": "index.js",
     "homepage": "https://github.com/girder/girder_volview",


### PR DESCRIPTION
- Fix recursive File.save() causing duplicate processing
- Buffer S3 files in memory before pydicom parsing
- Improves import speed by 15-19x (from ~2.1s to ~0.11s per file)