### PR TITLE
filter-linked VolView sessions for grouped DICOM rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,15 @@ VolView creates a new session.volview.zip file in the Girder Item every time the
 1. If user clicks refresh in VolView, the `GET folder/:id/volview?items=[...ids]&folders=[...ids]` end point is hit again. If a session.volview.zip is in the `items` parameter, the plugin reads the volview.zip's `linkedResources` and searches for a newer session.volview.zips with matching `linkedResources` and returns that if found.
 1. If user checks a new set of folders or items that does not include a session.volview.zip item, the `GET folder/:id/volview` endpoint does not pick a session.volview.zip with matching `linkedResources` as `lastOpened` metadata on one of the checked items/folders is newer than the matching session.volview.zip. This allows opening of images with a clean slate.
 
+### Open Filter-Linked Session (Grouped DICOM Row)
+
+Filter-linked sessions use `linkedResources.filter` (a metadata-key/value dict like `{"meta.dicom.StudyInstanceUID": "..."}`) in place of explicit item/folder IDs. The grouped DICOM row opener produces these.
+
+1. User clicks Open on a grouped row. Browser opens VolView with a manifest URL of `GET folder/:id/volview?filters={...}`. The endpoint returns the newest session.volview.zip whose `linkedResources.filter` is *equal* to the row's filter (strict set-equality on the filter list); if none exists, it returns the raw DICOM files matching the filter.
+1. User clicks Save. A new session.volview.zip is created in the folder with the row's filter recorded under `linkedResources.filter`.
+1. User clicks refresh in VolView. The same `?filters={...}` URL is hit again and now resolves to the just-saved session (newest matching by `getTouchedTime`, which honors `meta.lastOpened`).
+1. User checks an older filter-linked session item in the file browser and clicks "Open Checked in VolView". Client bumps `lastOpened` on the checked item, then opens VolView with `?items=<id>`. The endpoint reads the checked session's `linkedResources.filter` and returns the newest matching session — which is the just-touched older one. Subsequent saves create newer matching sessions; refresh picks them up via the same touched-time rule. This is what makes "go back in history" and "refresh after save" use the same code path.
+
 ## Development
 
 Get this running https://github.com/DigitalSlideArchive/digital_slide_archive/tree/master/devops/with-dive-volview

--- a/girder_volview/__init__.py
+++ b/girder_volview/__init__.py
@@ -15,7 +15,7 @@ from girder.constants import AccessType, TokenScope, SortDir
 from girder.models.file import File
 from girder.models.upload import Upload
 from girder.utility import RequestBodyStream
-from girder.exceptions import GirderException
+from girder.exceptions import GirderException, RestException
 
 from girder.models.item import Item
 from girder.utility import ziputil
@@ -49,6 +49,7 @@ from .utils import (
     getTouchedTime,
     getFilteredFiles,
     getFilteredSessionFile,
+    sessionNameFromFilter,
 )
 
 LARGE_IMAGE_CONFIG_FOLDER = "large_image.config_folder"
@@ -165,11 +166,10 @@ def uploadSession(model, parentId, user, size, metadata=None):
     parentType = model.__name__.lower()
     name = f"session{SESSION_ZIP_EXTENSION}"
     try:
-        # If the session was created due to a filter, include that as part of
-        # the name.  Don't fail if it isn't formated as we expect.
-        if metadata and metadata.get('linkedResources') and metadata['linkedResources'].get('filter'):
-            firstFilter = list(iter(metadata['linkedResources']['filter'].values()))[0]
-            name = f'session.{firstFilter}{SESSION_ZIP_EXTENSION}'
+        # Metadata comes from the client; don't fail the save if the shape
+        # isn't what we expect.
+        linkedFilter = (metadata or {}).get("linkedResources", {}).get("filter")
+        name = sessionNameFromFilter(linkedFilter, SESSION_ZIP_EXTENSION)
     except Exception:
         pass
 
@@ -383,7 +383,7 @@ def downloadManifest(self, item):
     .modelParam("folderId", model=Folder, level=AccessType.READ)
     .param("folders", "Folder IDs.", required=False)
     .param("items", "Item IDs.", required=False)
-    .jsonParam("filters", "Filters to apply within a folder.", required=False, requireObject=True)
+    .jsonParam("filters", "Filter (dict) or filter list (array of dicts) to apply within a folder.", required=False)
     .produces(["application/json"])
     .errorResponse("ID was invalid.")
     .errorResponse("Read access was denied for the folders or items.", 403)
@@ -392,6 +392,11 @@ def downloadResourceManifest(self, folder, folders, items, filters):
     user = self.getCurrentUser()
     folders = idStringToIdList(folders or '')
     items = idStringToIdList(items or '')
+    # filters is either a dict, a list of dicts, or absent. Anything else
+    # (bare scalar, null parsed to None already short-circuits via `if not
+    # filters`) gets rejected here rather than 500ing in Mongo.
+    if filters is not None and not isinstance(filters, (dict, list)):
+        raise RestException("filters must be a JSON object or array of objects")
     files = []
     if not folders and not items:
         if not filters:
@@ -400,7 +405,9 @@ def downloadResourceManifest(self, folder, folders, items, filters):
                 fileEntry
                 for fileEntry in Folder().fileList(folder, subpath=False, data=False)
             ]
-            files = singleVolViewZipOrImageFiles(filesInFolder, user=user)
+            files = singleVolViewZipOrImageFiles(
+                filesInFolder, user=user, includeFilterLinkedSessions=False,
+            )
         else:
             files = getFilteredSessionFile(folder, filters, user)
             if files is None:
@@ -414,6 +421,15 @@ def downloadResourceManifest(self, folder, folders, items, filters):
         newestSelectedSession = findNewestSession(selectedItems)
         if newestSelectedSession:
             linkedResources = getLinkedResources(newestSelectedSession)
+            linkedFilter = linkedResources.get("filter")
+            if linkedFilter:
+                files = getFilteredSessionFile(folder, linkedFilter, user)
+                if files is None:
+                    files = singleVolViewZipOrImageFiles(
+                        Item().fileList(newestSelectedSession, subpath=False, data=False),
+                        user=user,
+                    )
+                return filesToManifest(files, folder["_id"])
             folders = linkedResources["folders"]
             items = linkedResources["items"]
 

--- a/girder_volview/utils.py
+++ b/girder_volview/utils.py
@@ -9,6 +9,66 @@ SESSION_ZIP_EXTENSION = ".volview.zip"
 SESSION_JSON_EXTENSION = ".volview.json"
 SESSION_EXTENSIONS = (SESSION_ZIP_EXTENSION, SESSION_JSON_EXTENSION)
 
+SAFE_NAME_MAX = 80
+SESSION_NAME_MAX = SAFE_NAME_MAX * 3
+# Suffix-matched against filter keys so both 'meta.dicom.PatientID' and
+# 'dicom.PatientID' get the same canonical position.
+PREFERRED_FILTER_SUFFIXES = (
+    "PatientID",
+    "StudyInstanceUID",
+    "SeriesInstanceUID",
+)
+
+
+def safeNameComponent(value):
+    safe = "".join(
+        ch if ch.isalnum() or ch in ".-_" else "_" for ch in str(value)
+    )
+    return safe.strip("._")[:SAFE_NAME_MAX]
+
+
+def _filterKeyPriority(key):
+    keyStr = str(key)
+    for index, suffix in enumerate(PREFERRED_FILTER_SUFFIXES):
+        if keyStr.endswith(suffix):
+            return (0, index, keyStr)
+    return (1, 0, keyStr)
+
+
+def _promoteFilterToList(value):
+    """Normalize dict-or-list filter input to a list of dicts.
+    Returns None for non-conforming values.
+    """
+    if isinstance(value, dict):
+        return [value]
+    if isinstance(value, list) and all(isinstance(v, dict) for v in value):
+        return value
+    return None
+
+
+def sessionNameFromFilter(linkedFilter, extension):
+    filtersList = _promoteFilterToList(linkedFilter)
+    if not filtersList:
+        return f"session{extension}"
+    sortedFilters = sorted(
+        filtersList,
+        key=lambda d: tuple(sorted(d.items())),
+    )
+    parts = []
+    seen = set()
+    for filterDict in sortedFilters:
+        for key in sorted(filterDict, key=_filterKeyPriority):
+            component = safeNameComponent(filterDict[key])
+            if component and component not in seen:
+                parts.append(component)
+                seen.add(component)
+    if not parts:
+        return f"session{extension}"
+    joined = ".".join(parts)
+    if len(joined) > SESSION_NAME_MAX:
+        joined = joined[:SESSION_NAME_MAX].rstrip(".")
+    return f"session.{joined}{extension}"
+
 # https://github.com/Kitware/VolView/blob/main/src/io/mimeTypes.ts
 LOADABLE_EXTENSIONS = (
     # VolView app
@@ -175,9 +235,34 @@ def sameLevelSessionFile(fileEntry):
     return directChildSession and isSessionFile(fileEntry[1])
 
 
-def singleVolViewZipOrImageFiles(fileEntries, user=None):
+def filterLinkedSessionItemIds(fileEntries):
+    sessionItemIds = {
+        fileEntry[1].get("itemId")
+        for fileEntry in fileEntries
+        if sameLevelSessionFile(fileEntry) and fileEntry[1].get("itemId")
+    }
+    if not sessionItemIds:
+        return set()
+    matches = Item().find(
+        {
+            "_id": {"$in": list(sessionItemIds)},
+            "meta.linkedResources.filter": {"$exists": True},
+        },
+        fields=["_id"],
+    )
+    return {item["_id"] for item in matches}
+
+
+def singleVolViewZipOrImageFiles(fileEntries, user=None, includeFilterLinkedSessions=True):
+    fileEntries = list(fileEntries)
+    excludedItemIds = (
+        set() if includeFilterLinkedSessions
+        else filterLinkedSessionItemIds(fileEntries)
+    )
     sessions = [
-        fileEntry for fileEntry in fileEntries if sameLevelSessionFile(fileEntry)
+        fileEntry for fileEntry in fileEntries
+        if sameLevelSessionFile(fileEntry)
+        and fileEntry[1].get("itemId") not in excludedItemIds
     ]
     if sessions:
         # load latest session
@@ -210,8 +295,8 @@ def normalizeLinkedResources(linkedResources):
     folders = linkedResources.get("folders", [])
     items = linkedResources.get("items", [])
     result = {"folders": folders, "items": items}
-    if 'filters' in linkedResources:
-        result['fitlers'] = linkedResources['filters']
+    if 'filter' in linkedResources:
+        result['filter'] = linkedResources['filter']
     return result
 
 
@@ -230,8 +315,8 @@ def matchesSelectionSet(folders, items, item):
 
 
 def getTouchedTime(item):
-    if item.get("meta").get("lastOpened"):
-        dateString = item.get("meta").get("lastOpened")
+    if item.get("meta", {}).get("lastOpened"):
+        dateString = item.get("meta", {}).get("lastOpened")
         return datetime.strptime(dateString, "%Y-%m-%dT%H:%M:%S.%fZ")
     return item.get("updated") or item.get("created")
 
@@ -253,7 +338,15 @@ def getFilteredFiles(folder, filters):
     """
     Given a folder and a set of item filter criteria, find all files that are
     in items in the folder or any of its sub-folders that match the filter.
+    Accepts a single filter dict or a list of dicts (OR-unioned).
     """
+    filtersList = _promoteFilterToList(filters) or []
+    if len(filtersList) > 1:
+        itemMatch = {'$or': filtersList}
+    elif filtersList:
+        itemMatch = filtersList[0]
+    else:
+        itemMatch = {}
     folderId = folder['_id']
     pipeline = [
         {'$match': {'_id': folderId}},
@@ -278,7 +371,7 @@ def getFilteredFiles(folder, filters):
         }},
         {'$unwind': '$items'},
         {'$replaceRoot': {'newRoot': '$items'}},
-        {'$match': filters},
+        {'$match': itemMatch},
         {'$lookup': {
             'from': 'file',
             'localField': '_id',
@@ -293,11 +386,40 @@ def getFilteredFiles(folder, filters):
     return filesInFolder
 
 
+def filterMatchesSession(rowFilter, sessionFilter):
+    """A row filter matches a session filter when they have the same set of
+    filter dicts. Both arguments may be a single dict or a list of dicts; a
+    dict is treated as a single-element list. Order is irrelevant; cardinality
+    must match and each dict must be content-equal to a counterpart on the
+    other side.
+    """
+    rowList = _promoteFilterToList(rowFilter)
+    sessionList = _promoteFilterToList(sessionFilter)
+    if rowList is None or sessionList is None:
+        return False
+
+    def canon(d):
+        return tuple(sorted(d.items()))
+
+    return sorted(map(canon, rowList)) == sorted(map(canon, sessionList))
+
+
 def getFilteredSessionFile(folder, filters, user):
-    items = list(Item().find({'folderId': folder['_id'], 'meta.linkedResources.filter': filters}))
-    item = findNewestSession(items)
+    candidates = list(Item().find(
+        {
+            'folderId': folder['_id'],
+            'meta.linkedResources.filter': {'$exists': True},
+        },
+        fields=['_id', 'name', 'meta.linkedResources', 'meta.lastOpened', 'updated', 'created'],
+    ))
+    matches = [
+        item for item in candidates
+        if filterMatchesSession(filters, item.get('meta', {}).get('linkedResources', {}).get('filter'))
+    ]
+    item = findNewestSession(matches)
     if not item:
         return None
+    item = Item().load(item['_id'], user=user, level=AccessType.READ)
     files = singleVolViewZipOrImageFiles(
         Item().fileList(item, subpath=False, data=False), user=user,
     )

--- a/girder_volview/web_client/package.json
+++ b/girder_volview/web_client/package.json
@@ -7,7 +7,7 @@
     "license": "Apache-2.0",
     "dependencies": {
         "copy-webpack-plugin": "^4.5.2",
-        "volview": "4.4.2-dev.5b2b4b93f5a91629ae793d37bdee97134fd5fcea.0"
+        "volview": "4.4.2-dev.a66d1cfc6b3ebc1779173f71a200a42e2f55baad.0"
     },
     "peerDependencies": {
         "@girder/core": "*"

--- a/girder_volview/web_client/views/HierarchyWidget.js
+++ b/girder_volview/web_client/views/HierarchyWidget.js
@@ -3,7 +3,16 @@ import ItemListWidget from "@girder/large_image/views/itemList";
 import { restRequest } from "@girder/core/rest";
 import { confirm } from "@girder/core/dialog";
 import { wrap } from "@girder/core/utilities/PluginUtils";
-import { addButton, openResources, openGroupedItemURL, openItemURL, openResourcesURL } from "./open";
+import {
+    addButton,
+    groupingFilterForItem,
+    openCheckedGrouped,
+    openCheckedGroupedURL,
+    openGroupedItemURL,
+    openItemURL,
+    openResources,
+    openResourcesURL,
+} from "./open";
 
 const openFolder = '<i class="icon-link-ext"></i>Open Folder in VolView</a>';
 const openChecked = '<i class="icon-link-ext"></i>Open Checked in VolView</a>';
@@ -30,6 +39,27 @@ function updateButtonVisibility(el, folderId) {
         const loadable = loadableJSON.loadable;
         setButtonVisibility(el, loadable);
     });
+}
+
+function isGroupedItemList(itemListView) {
+    if (!itemListView || typeof itemListView._confList !== "function") {
+        return false;
+    }
+    const conf = itemListView._confList();
+    return !!(conf && conf.group && conf.group.keys && conf.group.keys.length);
+}
+
+function checkedGroupingFilters(itemListView, resources) {
+    if (!isGroupedItemList(itemListView)) {
+        return null;
+    }
+    const ids = (resources && resources.item) || [];
+    const filters = ids
+        .map((cid) => itemListView.collection.get(cid))
+        .filter((model) => model && (model.get("meta") || {})._grouping)
+        .map((model) => groupingFilterForItem(model))
+        .filter((f) => Object.keys(f).length > 0);
+    return filters.length ? filters : null;
 }
 
 function loadResources(parentModel, resources) {
@@ -75,6 +105,12 @@ wrap(HierarchyWidget, "render", function (render) {
     button.onclick = () => {
         const resources = JSON.parse(this._getCheckedResourceParam());
 
+        const groupedFilters = checkedGroupingFilters(this.itemListView, resources);
+        if (groupedFilters) {
+            openCheckedGrouped(this.parentModel, groupedFilters);
+            return false;
+        }
+
         if (resources.item && resources.item.length > 0) {
             const items = resources.item.map((cid) =>
                 this.itemListView.collection.get(cid)
@@ -115,8 +151,19 @@ wrap(HierarchyWidget, "render", function (render) {
     };
 
     const updateChecked = () => {
-        const resources = this._getCheckedResourceParam();
-        button.innerHTML = resources.length >= 3 ? openChecked : openFolder;
+        const resourceParam = this._getCheckedResourceParam();
+        const resources = JSON.parse(resourceParam);
+        const groupedFilters = checkedGroupingFilters(this.itemListView, resources);
+        if (groupedFilters) {
+            button.innerHTML = openChecked;
+            $(button).attr('href', openCheckedGroupedURL(this.parentModel, groupedFilters));
+            return;
+        }
+        const hasResources = (
+            (resources.item && resources.item.length) ||
+            (resources.folder && resources.folder.length)
+        );
+        button.innerHTML = hasResources ? openChecked : openFolder;
         $(button).attr('href', openResourcesURL(this.parentModel, resources));
     };
     updateChecked();

--- a/girder_volview/web_client/views/open.js
+++ b/girder_volview/web_client/views/open.js
@@ -58,22 +58,39 @@ export function openResources(folder, resources) {
     window.open(openResourcesURL(folder, resources), "_blank").focus();
 }
 
-export function openGroupedItemURL(item, folder) {
-    const folderId = folder ? folder.id : item.get('folderId');
-    const folderRoute = `/${getApiRoot()}/folder/${folderId}`;
-    const groups = item.get('meta')._grouping || {};
+export function groupingFilterForItem(item) {
+    const groups = (item.get('meta') || {})._grouping || {};
     const filter = {};
     (groups.keys || []).forEach((key, idx) => {
         if ((groups.values || [])[idx] !== undefined) {
             filter[key] = groups.values[idx];
         }
     });
-    const metaData = {linkedResources: {filter: filter}};
+    return filter;
+}
+
+function volViewURLWithFilter(folderId, filterPayload) {
+    const folderRoute = `/${getApiRoot()}/folder/${folderId}`;
+    const metaData = {linkedResources: {filter: filterPayload}};
     const saveParam = `&save=${folderRoute}/volview?metadata=${encodeURIComponent(
         JSON.stringify(metaData)
     )}`;
-    const manifestUrl = `/${getApiRoot()}/folder/${folderId}/volview?filters=${JSON.stringify(filter)}`;
+    const manifestUrl = `/${getApiRoot()}/folder/${folderId}/volview?filters=${encodeURIComponent(
+        JSON.stringify(filterPayload)
+    )}`;
     const downloadParams = `&names=[manifest.json]&urls=${encodeURIComponent(manifestUrl)}`;
-    const newTabUrl = `${volViewPath}?${saveParam}${downloadParams}`;
-    return newTabUrl;
+    return `${volViewPath}?${saveParam}${downloadParams}`;
+}
+
+export function openGroupedItemURL(item, folder) {
+    const folderId = folder ? folder.id : item.get('folderId');
+    return volViewURLWithFilter(folderId, groupingFilterForItem(item));
+}
+
+export function openCheckedGroupedURL(folder, filterList) {
+    return volViewURLWithFilter(folder.id, filterList);
+}
+
+export function openCheckedGrouped(folder, filterList) {
+    window.open(openCheckedGroupedURL(folder, filterList), "_blank").focus();
 }

--- a/tests/test_filter_match.py
+++ b/tests/test_filter_match.py
@@ -1,0 +1,114 @@
+from girder_volview.utils import filterMatchesSession
+
+
+def test_exact_match():
+    assert filterMatchesSession(
+        {"meta.dicom.StudyInstanceUID": "X"},
+        {"meta.dicom.StudyInstanceUID": "X"},
+    )
+
+
+def test_row_with_extra_keys_does_not_match_coarser_session():
+    # Row carries Patient+Study; session has only Study. Different dicts.
+    assert not filterMatchesSession(
+        {"meta.dicom.PatientID": "P", "meta.dicom.StudyInstanceUID": "X"},
+        {"meta.dicom.StudyInstanceUID": "X"},
+    )
+
+
+def test_coarser_row_does_not_match_session_with_extra_keys():
+    # Row has Study only; session has Patient+Study. Strict equality => no match.
+    assert not filterMatchesSession(
+        {"meta.dicom.StudyInstanceUID": "X"},
+        {"meta.dicom.PatientID": "P", "meta.dicom.StudyInstanceUID": "X"},
+    )
+
+
+def test_session_missing_key():
+    assert not filterMatchesSession(
+        {"meta.dicom.StudyInstanceUID": "X"},
+        {"meta.dicom.PatientID": "P"},
+    )
+
+
+def test_value_mismatch():
+    assert not filterMatchesSession(
+        {"meta.dicom.StudyInstanceUID": "X"},
+        {"meta.dicom.StudyInstanceUID": "Y"},
+    )
+
+
+def test_empty_row_filter_does_not_match_non_empty_session():
+    assert not filterMatchesSession({}, {"meta.dicom.StudyInstanceUID": "X"})
+
+
+def test_empty_row_filter_matches_empty_session():
+    assert filterMatchesSession({}, {})
+    assert filterMatchesSession([], [])
+
+
+def test_empty_list_row_does_not_match_non_empty_session():
+    assert not filterMatchesSession([], {"k": "v"})
+    assert not filterMatchesSession([], [{"k": "v"}])
+
+
+def test_non_dict_inputs_do_not_match():
+    assert not filterMatchesSession(None, {"k": "v"})
+    assert not filterMatchesSession({"k": "v"}, None)
+    assert not filterMatchesSession("k=v", {"k": "v"})
+
+
+def test_list_row_matches_list_session_when_each_element_covered():
+    assert filterMatchesSession(
+        [{"meta.dicom.StudyInstanceUID": "A"}, {"meta.dicom.StudyInstanceUID": "B"}],
+        [{"meta.dicom.StudyInstanceUID": "A"}, {"meta.dicom.StudyInstanceUID": "B"}],
+    )
+
+
+def test_list_row_no_match_when_session_missing_element():
+    assert not filterMatchesSession(
+        [{"meta.dicom.StudyInstanceUID": "A"}, {"meta.dicom.StudyInstanceUID": "B"}],
+        [{"meta.dicom.StudyInstanceUID": "A"}],
+    )
+
+
+def test_list_row_session_with_extra_element_does_not_match():
+    # Strict equality: extra elements on either side break the match.
+    assert not filterMatchesSession(
+        [{"meta.dicom.StudyInstanceUID": "A"}, {"meta.dicom.StudyInstanceUID": "B"}],
+        [
+            {"meta.dicom.StudyInstanceUID": "A"},
+            {"meta.dicom.StudyInstanceUID": "B"},
+            {"meta.dicom.StudyInstanceUID": "C"},
+        ],
+    )
+
+
+def test_dict_row_does_not_match_multi_element_session():
+    # Single-row open does not pull in a multi-filter session.
+    assert not filterMatchesSession(
+        {"meta.dicom.StudyInstanceUID": "A"},
+        [{"meta.dicom.StudyInstanceUID": "A"}, {"meta.dicom.StudyInstanceUID": "B"}],
+    )
+
+
+def test_list_row_matches_dict_session_legacy():
+    # Legacy single-filter session against a single-element row list.
+    assert filterMatchesSession(
+        [{"meta.dicom.StudyInstanceUID": "A"}],
+        {"meta.dicom.StudyInstanceUID": "A"},
+    )
+
+
+def test_list_with_non_dict_element_rejected():
+    assert not filterMatchesSession(
+        [{"k": "v"}, "not a dict"],
+        [{"k": "v"}],
+    )
+
+
+def test_order_independent():
+    assert filterMatchesSession(
+        [{"meta.dicom.StudyInstanceUID": "A"}, {"meta.dicom.StudyInstanceUID": "B"}],
+        [{"meta.dicom.StudyInstanceUID": "B"}, {"meta.dicom.StudyInstanceUID": "A"}],
+    )

--- a/tests/test_session_name.py
+++ b/tests/test_session_name.py
@@ -1,0 +1,101 @@
+from girder_volview.utils import sessionNameFromFilter
+
+
+ZIP = ".volview.zip"
+
+
+def test_empty_filter_uses_bare_session_name():
+    assert sessionNameFromFilter(None, ZIP) == "session.volview.zip"
+    assert sessionNameFromFilter({}, ZIP) == "session.volview.zip"
+
+
+def test_single_key_filter():
+    name = sessionNameFromFilter({"meta.dicom.PatientID": "P"}, ZIP)
+    assert name == "session.P.volview.zip"
+
+
+def test_multi_key_filter_is_order_independent():
+    patient_first = sessionNameFromFilter(
+        {
+            "meta.dicom.PatientID": "P",
+            "meta.dicom.StudyInstanceUID": "S",
+        },
+        ZIP,
+    )
+    study_first = sessionNameFromFilter(
+        {
+            "meta.dicom.StudyInstanceUID": "S",
+            "meta.dicom.PatientID": "P",
+        },
+        ZIP,
+    )
+    assert patient_first == study_first == "session.P.S.volview.zip"
+
+
+def test_series_uid_canonical_position():
+    name = sessionNameFromFilter(
+        {
+            "meta.dicom.SeriesInstanceUID": "R",
+            "meta.dicom.PatientID": "P",
+            "meta.dicom.StudyInstanceUID": "S",
+        },
+        ZIP,
+    )
+    assert name == "session.P.S.R.volview.zip"
+
+
+def test_unknown_key_falls_after_preferred_and_sorts():
+    name = sessionNameFromFilter(
+        {
+            "meta.dicom.StudyInstanceUID": "S",
+            "foo": "F",
+        },
+        ZIP,
+    )
+    assert name == "session.S.F.volview.zip"
+
+
+def test_values_are_sanitized():
+    name = sessionNameFromFilter(
+        {"meta.dicom.PatientID": "1.2/3 4"},
+        ZIP,
+    )
+    assert name == "session.1.2_3_4.volview.zip"
+
+
+def test_list_filter_two_studies():
+    name = sessionNameFromFilter(
+        [
+            {"meta.dicom.StudyInstanceUID": "A"},
+            {"meta.dicom.StudyInstanceUID": "B"},
+        ],
+        ZIP,
+    )
+    assert name == "session.A.B.volview.zip"
+
+
+def test_list_filter_dedupes_repeated_values():
+    name = sessionNameFromFilter(
+        [
+            {"meta.dicom.PatientID": "P", "meta.dicom.StudyInstanceUID": "A"},
+            {"meta.dicom.PatientID": "P", "meta.dicom.StudyInstanceUID": "B"},
+        ],
+        ZIP,
+    )
+    assert name == "session.P.A.B.volview.zip"
+
+
+def test_empty_list_filter_uses_bare_session_name():
+    assert sessionNameFromFilter([], ZIP) == "session.volview.zip"
+
+
+def test_single_element_list_matches_dict_form():
+    list_form = sessionNameFromFilter(
+        [{"meta.dicom.StudyInstanceUID": "S"}],
+        ZIP,
+    )
+    dict_form = sessionNameFromFilter(
+        {"meta.dicom.StudyInstanceUID": "S"},
+        ZIP,
+    )
+    assert list_form == dict_form == "session.S.volview.zip"


### PR DESCRIPTION
Adds support for opening one session per DICOM study from grouped folder views.

  - **Server**: `linkedResources.filter` on session items resolves the matching session via `getFilteredSessionFile`. Filter-linked sessions are excluded from folder-level
  opens (`includeFilterLinkedSessions=False`).
  - **session_builder**: new `dicom_study_sessions` helper discovers DICOM items under a folder, groups by configurable metadata keys (default `meta.dicom.StudyInstanceUID`),
   and uploads one `session.<study>.volview.json` per study with the filter set.
  - **Client**: Open Folder / Open Checked label now toggles from the parsed `resource` param instead of string length.
  - **Fixes**: `fitlers` → `filters` typo in `normalizeLinkedResources`; `KeyError` in `getTouchedTime` when `meta` is missing.